### PR TITLE
Updating run.sh and prepare_data.py for hkust

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,13 @@ __pycache__
 tags
 .vscode/*
 
+/athena.egg-info/
+/athena/transform/feats/ops/x_ops.so
+
+/build
+
+/dist
+
+/tools/kenlm
 /tools/sph2pipe_v2.5.tar.gz
-/tools/sph2pipe_v2.5
+/tools/sph2pipe

--- a/examples/asr/hkust/run.sh
+++ b/examples/asr/hkust/run.sh
@@ -24,49 +24,54 @@ source tools/env.sh
 
 stage=0
 stop_stage=100
+dataset_dir=/nfs/project/datasets/opensource_data/hkust
 
 if [ ${stage} -le 0 ] && [ ${stop_stage} -ge 0 ]; then
     # prepare data
     echo "Preparing data"
-    python examples/asr/hkust/local/prepare_data.py /nfs/project/datasets/opensource_data/hkust
-    mkdir -p examples/asr/hkust/data
-    cp /nfs/project/datasets/opensource_data/hkust/{train,dev}.csv examples/asr/hkust/data/
+    mkdir -p examples/asr/hkust/data || exit 1
+    python examples/asr/hkust/local/prepare_data.py \
+        $dataset_dir examples/asr/hkust/data || exit 1
 
-    # cal cmvn
+    # calculate cmvn
     cat examples/asr/hkust/data/train.csv > examples/asr/hkust/data/all.csv
     tail -n +2 examples/asr/hkust/data/dev.csv >> examples/asr/hkust/data/all.csv
-    tail -n +2 examples/asr/hkust/data/test.csv >> examples/asr/hkust/data/all.csv
-    python athena/cmvn_main.py examples/asr/hkust/mpc.json examples/asr/hkust/data/all.csv
+    python athena/cmvn_main.py \
+      examples/asr/hkust/mpc.json examples/asr/hkust/data/all.csv || exit 1
 fi
 
 if [ ${stage} -le 1 ] && [ ${stop_stage} -ge 1 ]; then
     # pretrain stage
     echo "Pretraining"
-    python athena/main.py examples/asr/hkust/mpc.json
+    python athena/main.py examples/asr/hkust/mpc.json || exit 1
 fi
 
 if [ ${stage} -le 2 ] && [ ${stop_stage} -ge 2 ]; then
     # finetuning stage
     echo "Fine-tuning"
-    python athena/main.py examples/asr/hkust/mtl_transformer.json
+    python athena/main.py examples/asr/hkust/mtl_transformer.json || exit 1
 fi
 
 if [ ${stage} -le 3 ] && [ ${stop_stage} -ge 3 ]; then
     # decoding stage
     echo "Decoding"
     # prepare language model
-    tail -n +2 examples/asr/hkust/data/train.csv | cut -f 3 > examples/asr/hkust/data/text
-    python examples/asr/hkust/local/segment_word.py examples/asr/hkust/data/vocab \
-       examples/asr/hkust/data/text > examples/asr/hkust/data/text.seg
-    tools/kenlm/build/bin/lmplz -o 4 < examples/asr/hkust/data/text.seg > examples/asr/hkust/data/4gram.arpa
+    tail -n +2 examples/asr/hkust/data/train.csv |\
+        cut -f 3 > examples/asr/hkust/data/text || exit 1
+    python examples/asr/hkust/local/segment_word.py \
+        examples/asr/hkust/data/vocab \
+        examples/asr/hkust/data/text \
+        > examples/asr/hkust/data/text.seg || exit 1
+    tools/kenlm/build/bin/lmplz -o 4 < examples/asr/hkust/data/text.seg \
+        > examples/asr/hkust/data/4gram.arpa || exit 1
 
-    python athena/decode_main.py examples/asr/hkust/mtl_transformer.json
+    python athena/decode_main.py examples/asr/hkust/mtl_transformer.json || exit 1
 fi
 
 if [ ${stage} -le 4 ] && [ ${stop_stage} -ge 4 ]; then
     echo "training rnnlm"
     tail -n +2 examples/asr/hkust/data/train.csv | awk '{print $3"\t"$3}' > examples/asr/hkust/data/train.trans.csv
     tail -n +2 examples/asr/hkust/data/dev.csv | awk '{print $3"\t"$3}' > examples/asr/hkust/data/dev.trans.csv
-    python athena/main.py examples/asr/hkust/rnnlm.json
+    python athena/main.py examples/asr/hkust/rnnlm.json || exit 1
 fi
 

--- a/tools/install_sph2pipe.sh
+++ b/tools/install_sph2pipe.sh
@@ -5,6 +5,8 @@ if [ ! -e sph2pipe_v2.5.tar.gz ]; then
   wget -T 10 -t 3 http://www.openslr.org/resources/3/sph2pipe_v2.5.tar.gz || exit 1
 fi
 
+rm -rf sph2pipe_v2.5 sph2pipe
 tar -zxvf sph2pipe_v2.5.tar.gz || exit 1
-cd sph2pipe_v2.5/
+mv sph2pipe_v2.5 sph2pipe
+cd sph2pipe
 gcc -o sph2pipe  *.c -lm || exit 1


### PR DESCRIPTION
@tjadamlee this PR needs your special attention as it may break your current runs. Changes and also the reasoning below:

1. prepare_data.py now takes an input directory (the dataset) and an output directory (examples/asr/hkust/data). This way, we don't have to modify the original dataset, as we don't want to mess up with the original copy, and they are usually read-only anyways on a lot of servers. The output directory also acts as the working directory where we can write temporary files.

2. Changed sph2pipe to athena/tools/sph2pipe/sph2pipe. We will start using third party tools under athena/tools/ (e.g., for sph2pipe, kenlm). We may need to update the installation process so that also the third party tools will be properly installed upon installation.

3. Added exit to run.sh so that we can catch errors properly from pipe.