### PR TITLE
Change MPC pretraining epoch to 250 for AISHELL dataset. Update WER of pre-training and non-pre-training model on the AISHELL dataset.

### DIFF
--- a/examples/asr/README.md
+++ b/examples/asr/README.md
@@ -25,7 +25,7 @@ bash examples/asr/$task_name/run.sh
 | Error Rate (CER for Mandarin, WER for English)  |  without MPC/%     |     with MPC/%   |
 | :-------------: | :----------: | :-----------: |
 |  HKUST          | 23.30        | 22.98         |
-| AISEHLL         | 7.00         |               |
+| AISEHLL         | 5.97         | 5.77          |
 | Librispeech     |              |               |
 | switchboard_fisher |           |               |
 

--- a/examples/asr/aishell/configs/mpc.json
+++ b/examples/asr/aishell/configs/mpc.json
@@ -1,6 +1,6 @@
 {
   "batch_size":64,
-  "num_epochs":100,
+  "num_epochs":250,
   "sorta_epoch":1,
   "ckpt":"examples/asr/aishell/ckpts/mpc",
   "summary_dir":"examples/asr/aishell/ckpts/mpc/event",


### PR DESCRIPTION
We pre-training MPC over 250 epochs on the AISHELL dataset, relatively improved 3% in WER.