### PR TITLE
fix the bug of tokenizer

### DIFF
--- a/athena/data/datasets/speech_recognition.py
+++ b/athena/data/datasets/speech_recognition.py
@@ -115,9 +115,9 @@ class SpeechRecognitionDatasetBuilder(BaseDatasetBuilder):
 
         # handling special case for text_featurizer
         self.entries.sort(key=lambda item: float(item[1]))
-        if self.text_featurizer.model_type == "text":
-            _, _, all_transcripts, _, _ = zip(*self.entries)
-            self.text_featurizer.load_model(all_transcripts)
+        #if self.text_featurizer.model_type == "text":
+        #    _, _, all_transcripts, _, _ = zip(*self.entries)
+        #    self.text_featurizer.load_model(all_transcripts)
 
         # apply some filter
         self.filter_sample_by_unk()

--- a/athena/data/text_featurizer.py
+++ b/athena/data/text_featurizer.py
@@ -128,11 +128,20 @@ class SentencePieceFeaturizer:
 
 class TextTokenizer:
     """ Text Tokenizer """
-    def __init__(self, text=None):
+    def __init__(self, csv=None):
         self.tokenizer = tf.keras.preprocessing.text.Tokenizer()
-        self.text = text
-        if text is not None:
-            self.load_model(text)
+        if csv is not None:
+            text = self.load_text_from_csvs(csv)
+            self.model = self.load_model(text)
+
+    def load_text_from_csv(self, csv):
+        transcripts = []
+        with open(csv, "r", encoding="utf-8") as csv_file:
+            lines = csv_file.readlines()[1:]
+            for line in lines:
+                transcript = line.split("\t")[2]
+                transcripts.append(transcript)
+        return transcripts
 
     def load_model(self, text):
         """ load model """

--- a/athena/data/text_featurizer.py
+++ b/athena/data/text_featurizer.py
@@ -131,7 +131,7 @@ class TextTokenizer:
     def __init__(self, csv=None):
         self.tokenizer = tf.keras.preprocessing.text.Tokenizer()
         if csv is not None:
-            text = self.load_text_from_csvs(csv)
+            text = self.load_text_from_csv(csv)
             self.model = self.load_model(text)
 
     def load_text_from_csv(self, csv):


### PR DESCRIPTION
Assume we use text config like this in the json file:
"text_config": {"type":"text", "model":"examples/asr/timit/data/train.csv"}
the following mistakes occurs:

1. by default the string "examples/asr/timit/data/train.csv" will be seen as the "text" args in TextTokenizer init method, leading to be an unexpected text for tokenizer model.
2. for different sets written in json file, for examples, training set and dev set, speech_recognition.py loads tokenizer using different transcripts (all transcripts from training set when loading train.csv, and all transcripts from dev set when loading dev.csv), which makes the vocabulary for the dataset inconsistent during training